### PR TITLE
Add missing '-' to 'number' parameter

### DIFF
--- a/site/man/rabbitmq-diagnostics.8.html
+++ b/site/man/rabbitmq-diagnostics.8.html
@@ -463,7 +463,7 @@
     <p class="Pp">Prints the last N lines of the log on the node</p>
     <p class="Pp">Example:</p>
     <div class="Bd Bd-indent lang-bash"><code class="Li">rabbitmq-diagnostics log_tail
-      -number 100</code></div>
+      --number 100</code></div>
   </dd>
   <dt id="log_tail_stream"><a class="permalink" href="#log_tail_stream"><code class="Cm">log_tail_stream</code></a>
     [<code class="Fl">--duration</code> <var class="Ar">seconds</var> |


### PR DESCRIPTION
A '-' is missing before the `number` option in the example of the `rabbitmq-diagnostics log_tail` command.